### PR TITLE
Avoid words seperated by +

### DIFF
--- a/src/Type/AbstractType.php
+++ b/src/Type/AbstractType.php
@@ -144,7 +144,7 @@ abstract class AbstractType
             }
         }
 
-        return sprintf("%s://%s?%s", $this->scheme, $this->authority, http_build_query($data));
+        return sprintf("%s://%s?%s", $this->scheme, $this->authority, http_build_query($data, '', '&', PHP_QUERY_RFC3986));
     }
 
     /**


### PR DESCRIPTION
by default spaces in http_build_query encoded with +, should be %20
