### PR TITLE
remove deprecated QR lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,6 @@ Saving a BezahlCode to a file and getting the BezahlCode URI works as described 
 ## Credits
 
 * [Marcus Jaschen](https://github.com/mjaschen)
-* [PHP QR Code Library](http://phpqrcode.sourceforge.net)
-* [Ariel Ferrandini](https://github.com/aferrandini) - PHP QR Code Composer Package
+* [QR Code](https://github.com/endroid/qr-code)
 * [BezahlCode](http://www.bezahlcode.de/)
 * BezahlCode [Specification](http://www.bezahlcode.de/wp-content/uploads/BezahlCode_TechDok.pdf) (PDF)

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require" : {
         "php" : ">=5.3.0",
-        "aferrandini/phpqrcode" : "~1.0.1"
+        "endroid/qr-code" : "~3.2"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"

--- a/src/Type/AbstractType.php
+++ b/src/Type/AbstractType.php
@@ -16,7 +16,8 @@ namespace MarcusJaschen\BezahlCode\Type;
 
 use MarcusJaschen\BezahlCode\Type\Exception\InvalidParameterException;
 use MarcusJaschen\BezahlCode\Type\Exception\InvalidQRCodeParameterException;
-use PHPQRCode\QRcode;
+use Endroid\QrCode\QrCode;
+use Endroid\QrCode\ErrorCorrectionLevel;
 
 /**
  * Abstract BezahlCode Type Class
@@ -33,9 +34,9 @@ abstract class AbstractType
      * @var array
      */
     protected $qrSettings = array(
-        'level'  => 'L',
-        'size'   => 4,
-        'margin' => 4,
+        'level'  => ErrorCorrectionLevel::LOW,
+        'size'   => 300,
+        'margin' => 10,
     );
 
     /**
@@ -154,7 +155,12 @@ abstract class AbstractType
      */
     public function saveBezahlCode($file)
     {
-        QRcode::png($this->getBezahlCodeURI(), $file, $this->qrSettings['level'], $this->qrSettings['size'], $this->qrSettings['margin'], false);
+        $qrCode = new QRcode($this->getBezahlCodeURI());
+        $qrCode->setErrorCorrectionLevel($this->qrSettings['level']);
+        $qrCode->setSize($this->qrSettings['size']);
+        $qrCode->setMargin($this->qrSettings['margin']);
+        $qrCode->setWriterByName('png');
+        $qrCode->writeFile($file);
     }
 
     /**
@@ -164,9 +170,12 @@ abstract class AbstractType
      */
     public function getBezahlCode()
     {
-        ob_start();
-        QRcode::png($this->getBezahlCodeURI(), false, $this->qrSettings['level'], $this->qrSettings['size'], $this->qrSettings['margin'], false);
-        return ob_get_clean();
+        $qrCode = new QRcode($this->getBezahlCodeURI());
+        $qrCode->setErrorCorrectionLevel($this->qrSettings['level']);
+        $qrCode->setSize($this->qrSettings['size']);
+        $qrCode->setMargin($this->qrSettings['margin']);
+        $qrCode->setWriterByName('png');
+        return $qrCode->writeString();
     }
 
 }


### PR DESCRIPTION
I changed the used QRcode lib as the currently used is marked as deprecated in the composer repository. The new one is the suggested replacment.

This chnage is not backward compatible in regards of options. The size, margin and level parameters changed.